### PR TITLE
Update to emacs version 25.1.

### DIFF
--- a/emacs.nuspec
+++ b/emacs.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Emacs</id>
     <title>Emacs</title>
-    <version>24.5.0.20150611</version>
+    <version>25.1.0.20160917</version>
     <authors>The GNU Project</authors>
     <owners>Chris Bilson</owners>
     <summary>The Emacs editor</summary>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,6 +1,9 @@
-$emacsNameVersion = 'emacs-24.5'
-$src = "http://ftp.gnu.org/pub/gnu/emacs/windows/$($emacsNameVersion)-bin-i686-mingw32.zip"
+$emacsNameVersion = 'emacs-25.1'
+$url = "http://ftp.gnu.org/pub/gnu/emacs/windows/$($emacsNameVersion)-i686-w64-mingw32.zip"
+$url64 = "http://ftp.gnu.org/pub/gnu/emacs/windows/$($emacsNameVersion)-x86_64-w64-mingw32.zip"
 $toolsDir =  Split-Path -parent $MyInvocation.MyCommand.Definition
-Install-ChocolateyZipPackage 'Emacs' $src $toolsDir `
-  -Checksum B867F51AC412B848D3CB17FDC8896040 `
-  -ChecksumType MD5
+Install-ChocolateyZipPackage 'Emacs' $url $toolsDir $url64 `
+  -Checksum e4874839e6d164e74b023f091cd2f4545aeeee190a895c91b49670e11dfadaf7 `
+  -ChecksumType 'SHA256' `
+  -Checksum64 dd64f517c58226ccc385b6d06124a581337a4420b7e519664ed93fbbc505f2f9 `
+  -ChecksumType64 'SHA256'


### PR DESCRIPTION
This also adds the ability to install a 64 bit build of emacs, now that
one is available from upstream.
